### PR TITLE
Potential fix for issue with namespaces for deserializing xml rhino messages.

### DIFF
--- a/src/FubuTransportation.Testing/FubuTransportation.Testing.csproj
+++ b/src/FubuTransportation.Testing/FubuTransportation.Testing.csproj
@@ -522,6 +522,7 @@
     <Compile Include="Runtime\Serializers\EnvelopeSerializerTester.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Runtime\Serializers\XmlMessageSerializerRhinoMessageTester.cs" />
     <Compile Include="Runtime\Serializers\XmlMessageSerializerTester.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/FubuTransportation.Testing/Runtime/Serializers/XmlMessageSerializerRhinoMessageTester.cs
+++ b/src/FubuTransportation.Testing/Runtime/Serializers/XmlMessageSerializerRhinoMessageTester.cs
@@ -1,0 +1,47 @@
+﻿using System.IO;
+using FubuTestingSupport;
+using FubuTransportation.Runtime.Serializers;
+using NUnit.Framework;
+
+namespace FubuTransportation.Testing.Runtime.Serializers
+{
+    [TestFixture]
+    public class XmlMessageSerializerRhinoMessageTester
+    {
+        private readonly XmlMessageSerializer _serializer;
+        private readonly MemoryStream _stream;
+
+        private const string XmlInput = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <esb:messages xmlns:esb=""http://servicebus.hibernatingrhinos.com/2008/12/20/esb""
+                xmlns:commands.testrhinotoftserialization=""FubuTransportation.Testing.Runtime.Serializers.TestRhinoToFtSerialization, FubuTransportation.Testing""
+                xmlns:System.Int32=""System.Int32"">
+              <commands.testrhinotoftserialization:TestRhinoToFtSerialization>
+                <System.Int32:Id>1</System.Int32:Id>
+              </commands.testrhinotoftserialization:TestRhinoToFtSerialization>
+            </esb:messages>";
+
+
+        public XmlMessageSerializerRhinoMessageTester()
+        {
+            _serializer = new XmlMessageSerializer();
+            _stream = new MemoryStream();
+        }
+
+        [Test]
+        public void can_deserialize_rhino_esb_message()
+        {
+            var writer = new StreamWriter(_stream);
+            writer.Write(XmlInput);
+            writer.Flush();
+            _stream.Position = 0;
+
+            var result = (TestRhinoToFtSerialization) _serializer.Deserialize(_stream);
+            result.Id.ShouldEqual(1);
+        }
+    }
+
+    public class TestRhinoToFtSerialization
+    {
+        public int Id { get; set; }
+    }
+}

--- a/src/FubuTransportation/Runtime/Serializers/XmlMessageSerializer.cs
+++ b/src/FubuTransportation/Runtime/Serializers/XmlMessageSerializer.cs
@@ -278,12 +278,11 @@ namespace FubuTransportation.Runtime.Serializers
 
         public object Deserialize(Stream message)
         {
-            var namespaces = GetNamespaces(new object[0]);
             var document = XDocument.Load(XmlReader.Create(message));
             if (document.Root == null)
                 throw new SerializationException("document doesn't have root element");
 
-            if (document.Root.Name != namespaces["esb"] + "messages")
+            if (document.Root.Name.LocalName != "messages")
                 throw new SerializationException("message doesn't have root element named 'messages'");
 
             var msgs = new List<object>();


### PR DESCRIPTION
Not sure if this is the best way to do it, but its blowing up because the hardcoded `{"esb", "http://servicebus.fubutransportation.com/2013/07/19/esb"},`(XmlMessageSerializer.cs) is preventing the perfectly valid rhino messages from being parsed.
