### PR TITLE
Fixed in-memory code to still work after InMemoryTransport is cleared.  ...

### DIFF
--- a/src/FubuTransportation.Testing/InMemory/InMemoryQueueIntegrationTester.cs
+++ b/src/FubuTransportation.Testing/InMemory/InMemoryQueueIntegrationTester.cs
@@ -37,7 +37,7 @@ namespace FubuTransportation.Testing.InMemory
             envelope.Headers["Foo"] = "Bar";
             envelope.Data = new byte[] { 1, 2, 3, 4, 5 };
 
-            var queue = InMemoryQueueManager.QueueFor(new Uri("memory://foo"));
+            var queue = new InMemoryQueue(new Uri("memory://foo"));
 
             var receiver = new RecordingReceiver();
             var task = Task.Factory.StartNew(() => queue.Receive(receiver));

--- a/src/FubuTransportation/InMemory/InMemoryChannel.cs
+++ b/src/FubuTransportation/InMemory/InMemoryChannel.cs
@@ -20,6 +20,7 @@ namespace FubuTransportation.InMemory
         public void Dispose()
         {
             _queue.Dispose();
+            InMemoryQueueManager.Remove(_queue);
         }
 
         public Uri Address { get; private set; }

--- a/src/FubuTransportation/InMemory/InMemoryQueue.cs
+++ b/src/FubuTransportation/InMemory/InMemoryQueue.cs
@@ -77,7 +77,7 @@ namespace FubuTransportation.InMemory
 
                         receiver.Receive(token.Data, token.Headers, callback);
                     }
-                } 
+                }
             }
         }
 

--- a/src/FubuTransportation/InMemory/InMemoryQueueManager.cs
+++ b/src/FubuTransportation/InMemory/InMemoryQueueManager.cs
@@ -28,6 +28,11 @@ namespace FubuTransportation.InMemory
             _queues.Each(x => x.Clear());
         }
 
+        public static void Remove(InMemoryQueue queue)
+        {
+            _queues.Remove(queue.Uri);
+        }
+
         public static void AddToDelayedQueue(EnvelopeToken envelope)
         {
             _delayedLock.Write(() => {


### PR DESCRIPTION
...This was preventing the in-memory transport from working in StoryTeller, which would call ClearAll before each test.
