### PR TITLE
Updated SubscriptionCache to clear volatile nodes when state is reset fo...

### DIFF
--- a/src/FubuTransportation.Testing/FubuTransportation.Testing.csproj
+++ b/src/FubuTransportation.Testing/FubuTransportation.Testing.csproj
@@ -662,6 +662,7 @@
     <Compile Include="StubChannelNode.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Subscriptions\SubscriptionCache_clearing_tester.cs" />
     <Compile Include="Subscriptions\Subscription_equality_tester.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/FubuTransportation.Testing/Subscriptions/SubscriptionCache_clearing_tester.cs
+++ b/src/FubuTransportation.Testing/Subscriptions/SubscriptionCache_clearing_tester.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FubuTestingSupport;
+using FubuTransportation.Configuration;
+using FubuTransportation.InMemory;
+using FubuTransportation.Runtime;
+using FubuTransportation.Subscriptions;
+using NUnit.Framework;
+
+namespace FubuTransportation.Testing.Subscriptions
+{
+    [TestFixture]
+    public class SubscriptionCache_clearing_tester
+    {
+        private readonly SubscriptionCache _cache = new SubscriptionCache(
+            new ChannelGraph(),
+            new ITransport[] { new InMemoryTransport() });
+
+        [Test]
+        public void clears_all_subscriptions()
+        {
+            var subscriptions = new[]
+            {
+                ObjectMother.ExistingSubscription(),
+                ObjectMother.ExistingSubscription(),
+                ObjectMother.ExistingSubscription(),
+                ObjectMother.ExistingSubscription()
+            };
+
+            _cache.LoadSubscriptions(subscriptions);
+            _cache.ActiveSubscriptions.ShouldHaveTheSameElementsAs(subscriptions);
+
+            _cache.ClearAll();
+            _cache.ActiveSubscriptions.ShouldHaveCount(0);
+        }
+
+        [Test]
+        public void clears_volatile_nodes()
+        {
+            var envelope = ObjectMother.EnvelopeWithMessage();
+            var subscription = ObjectMother.ExistingSubscription();
+            subscription.MessageType = envelope.Message.GetType().FullName;
+
+            _cache.LoadSubscriptions(new[] { subscription });
+            IList<ChannelNode> channels = _cache.FindDestinationChannels(envelope).ToList();
+            channels.ShouldNotBeEmpty();
+            var oldNode = channels.Single();
+
+            _cache.ClearAll();
+            _cache.LoadSubscriptions(new[] { subscription });
+            channels = _cache.FindDestinationChannels(envelope).ToList();
+            channels.ShouldNotBeEmpty();
+            channels.ShouldNotContain(oldNode);
+        }
+    }
+}

--- a/src/FubuTransportation/Subscriptions/ISubscriptionCache.cs
+++ b/src/FubuTransportation/Subscriptions/ISubscriptionCache.cs
@@ -7,6 +7,8 @@ namespace FubuTransportation.Subscriptions
 {
     public interface ISubscriptionCache
     {
+        void ClearAll();
+
         IEnumerable<ChannelNode> FindDestinationChannels(Envelope envelope);
 
         Uri ReplyUriFor(ChannelNode destination);

--- a/src/FubuTransportation/Subscriptions/SubscriptionCache.cs
+++ b/src/FubuTransportation/Subscriptions/SubscriptionCache.cs
@@ -43,6 +43,18 @@ namespace FubuTransportation.Subscriptions
             });
         }
 
+        public void ClearAll()
+        {
+            _lock.Write(() =>
+            {
+                _routes.Clear();
+                _subscriptions.Clear();
+
+                _volatileNodes.Each(x => x.Dispose());
+                _volatileNodes.ClearAll();
+            });
+        }
+
         public IEnumerable<ChannelNode> FindDestinationChannels(Envelope envelope)
         {
             if (envelope.Destination != null)

--- a/src/FubuTransportation/TestSupport/TransportCleanup.cs
+++ b/src/FubuTransportation/TestSupport/TransportCleanup.cs
@@ -1,17 +1,19 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using FubuTransportation.Runtime;
+using FubuTransportation.Subscriptions;
 
 namespace FubuTransportation.TestSupport
 {
     public class TransportCleanup : Bottles.Services.Messaging.IListener<ClearAllTransports>
     {
         private readonly IEnumerable<ITransport> _transports;
+        private readonly ISubscriptionCache _subscriptions;
 
-        public TransportCleanup(IEnumerable<ITransport> transports)
+        public TransportCleanup(IEnumerable<ITransport> transports, ISubscriptionCache subscriptions)
         {
             _transports = transports;
+            _subscriptions = subscriptions;
         }
 
         public void Receive(ClearAllTransports message)
@@ -27,6 +29,7 @@ namespace FubuTransportation.TestSupport
                 Debug.WriteLine("Clearing up all messages on " + x);
                 x.ClearAll();
             });
+            _subscriptions.ClearAll();
         }
     }
 }


### PR DESCRIPTION
...r testing.  This prevents the cache from reusing disposed nodes.
