### PR TITLE
Removed the restriction on HandlerCalls that their return Type be a class

### DIFF
--- a/src/FubuTransportation.Testing/FakeHandlers.cs
+++ b/src/FubuTransportation.Testing/FakeHandlers.cs
@@ -1,4 +1,6 @@
-﻿namespace FubuTransportation.Testing
+﻿using FubuTransportation.Runtime.Cascading;
+
+namespace FubuTransportation.Testing
 {
 
     public interface ITargetHandler
@@ -10,6 +12,8 @@
         void ZeroInZeroOut();
 
         void ManyIn(Input i1, Input i2);
+
+        IImmediateContinuation ReturnsInterface(Input input);
     }
 
     public class Input

--- a/src/FubuTransportation.Testing/Registration/Nodes/HandlerCallTester.cs
+++ b/src/FubuTransportation.Testing/Registration/Nodes/HandlerCallTester.cs
@@ -88,6 +88,12 @@ namespace FubuTransportation.Testing.Registration.Nodes
         }
 
         [Test]
+        public void is_candidate_allows_interface_return_types()
+        {
+            HandlerCall.IsCandidate(ReflectionHelper.GetMethod<ITargetHandler>(x => x.ReturnsInterface(null))).ShouldBeTrue();
+        }
+
+        [Test]
         public void could_handle()
         {
             var handler1 = HandlerCall.For<SomeHandler>(x => x.Interface(null));

--- a/src/FubuTransportation/Registration/Nodes/HandlerCall.cs
+++ b/src/FubuTransportation/Registration/Nodes/HandlerCall.cs
@@ -23,16 +23,10 @@ namespace FubuTransportation.Registration.Nodes
             var parameterCount = method.GetParameters() == null ? 0 : method.GetParameters().Length;
             if (parameterCount != 1) return false;
 
-
-            var hasOutput = method.ReturnType != typeof(void);
-            if (hasOutput && !method.ReturnType.IsClass) return false;
-
             if (method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_")))
                 return false;
 
-            if (hasOutput) return true;
-
-            return parameterCount == 1;
+            return true;
         }
 
         public static HandlerCall For<T>(Expression<Action<T>> method)


### PR DESCRIPTION
This allows handlers to return IEnumerable when they have multiple cascading actions, or IImmediateContinuation, etc.

The IsCandidate() check has been cleaned up to remove redundancies.
