### PR TITLE
FubuTransportActFixture ClearHistory

### DIFF
--- a/src/FubuTransportation.Serenity/FubuTransportFixture.cs
+++ b/src/FubuTransportation.Serenity/FubuTransportFixture.cs
@@ -18,7 +18,7 @@ namespace FubuTransportation.Serenity
 
         protected static void startListening()
         {
-            MessageHistory.ClearAll();
+            MessageHistory.ClearHistory();
         }
 
         protected virtual void setup()


### PR DESCRIPTION
Don't want to call MessageHistory.ClearAll in the
FubuTransportActFixture since it'll remove the listener and the
MessageHistory won't work as expected.
