### PR TITLE
Changed MessageRecordListener to skip logging of polling jobs during testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ fubutransportation.esent
 fubutransportation.esent.*
 src/FubuTransportation.Docs/snippets
 *.stresult
+st-artifacts/
+st-results

--- a/src/FubuTransportation/Diagnostics/MessageRecord.cs
+++ b/src/FubuTransportation/Diagnostics/MessageRecord.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FubuCore;
+using FubuTransportation.Polling;
 using FubuTransportation.Runtime;
 using HtmlTags;
 
@@ -8,6 +10,7 @@ namespace FubuTransportation.Diagnostics
 {
     public class MessageRecord : MessageRecordNode
     {
+        private Type _messageType;
         public string Id;
         public string Message;
         public string Node;
@@ -26,10 +29,16 @@ namespace FubuTransportation.Diagnostics
             ParentId = envelope.ParentId;
             if (envelope.Message != null)
             {
-                Type = envelope.Message.GetType().FullName;
+                _messageType = envelope.Message.GetType();
+                Type = _messageType.FullName;
             }
 
             Headers = envelope.Headers.Keys().Select(x => "{0}={1}".ToFormat(x, envelope.Headers[x])).Join(";");
+        }
+
+        public bool IsPollingJobRelated()
+        {
+            return _messageType != null && _messageType.Closes(typeof(JobRequest<>));
         }
 
         public override HtmlTag ToLeafTag()

--- a/src/FubuTransportation/Diagnostics/MessageRecordListener.cs
+++ b/src/FubuTransportation/Diagnostics/MessageRecordListener.cs
@@ -22,7 +22,10 @@ namespace FubuTransportation.Diagnostics
 
         public void DebugMessage(object message)
         {
-            _session.Record(message.As<MessageLogRecord>().ToRecord());
+            var record = message.As<MessageLogRecord>().ToRecord();
+            if (record.IsPollingJobRelated()) return;
+
+            _session.Record(record);
         }
 
         public void InfoMessage(object message)


### PR DESCRIPTION
Using the same IsPollingJobRelated concept as EnvelopeToken
