### PR TITLE
Fixed LQ sending the wrong reply URI in messages

### DIFF
--- a/src/FubuTransportation.LightningQueues.Testing/LightningQueuesIntegrationTester.cs
+++ b/src/FubuTransportation.LightningQueues.Testing/LightningQueuesIntegrationTester.cs
@@ -23,9 +23,14 @@ namespace FubuTransportation.LightningQueues.Testing
         [SetUp]
         public void Setup()
         {
+            SetupTransport("lq.tcp://localhost:2032/upstream");
+        }
+
+        private void SetupTransport(string uri)
+        {
             graph = new ChannelGraph();
             node = graph.ChannelFor<ChannelSettings>(x => x.Upstream);
-            node.Uri = new Uri("lq.tcp://localhost:2032/upstream");
+            node.Uri = new Uri(uri);
             node.Incoming = true;
 
             var delayedCache = new DelayedMessageCache<MessageId>();
@@ -54,7 +59,16 @@ namespace FubuTransportation.LightningQueues.Testing
             uri.ShouldNotBeNull();
 
             uri.Host.ToUpperInvariant().ShouldEqual(Environment.MachineName.ToUpperInvariant());
+        }
 
+        [Test]
+        public void reply_uri_is_machine_specific_when_dns_address_is_used()
+        {
+            queues.Dispose();
+            SetupTransport("lq.tcp://www.foo.com:2032/upstream");
+
+            var uri = graph.ReplyChannelFor(LightningUri.Protocol);
+            uri.Host.ToUpperInvariant().ShouldEqual(Environment.MachineName.ToUpperInvariant());
         }
 
         [Test]

--- a/src/FubuTransportation.LightningQueues/LightningQueuesTransport.cs
+++ b/src/FubuTransportation.LightningQueues/LightningQueuesTransport.cs
@@ -74,7 +74,7 @@ namespace FubuTransportation.LightningQueues
             if (channelNode == null)
                 throw new InvalidOperationException("You must have at least one incoming Lightning Queue channel for accepting replies");
 
-            return channelNode.Channel.Address.ToMachineUri();
+            return channelNode.Channel.Address.ToLocalUri();
         }
     }
 }

--- a/src/FubuTransportation.LightningQueues/LightningUri.cs
+++ b/src/FubuTransportation.LightningQueues/LightningUri.cs
@@ -64,9 +64,14 @@ namespace FubuTransportation.LightningQueues
         {
             if (_locals.Contains(uri.Host))
             {
-                return new UriBuilder(uri) {Host = Environment.MachineName}.Uri;
+                return uri.ToLocalUri();
             }
             return uri;
+        }
+
+        public static Uri ToLocalUri(this Uri uri)
+        {
+            return new UriBuilder(uri) { Host = Environment.MachineName }.Uri;
         }
     }
 }


### PR DESCRIPTION
This was causing responses to possibly go to the wrong node