### PR TITLE
"Remove subscription" support

### DIFF
--- a/src/FubuTransportation.RavenDb.Testing/RavenDbSubscriptionPersistenceTester.cs
+++ b/src/FubuTransportation.RavenDb.Testing/RavenDbSubscriptionPersistenceTester.cs
@@ -152,5 +152,25 @@ namespace FubuTransportation.RavenDb.Testing
             persistence.LoadNode(node1.Id).OwnedTasks
                 .ShouldContain(subject);
         }
+
+        [Test]
+        public void delete_susbscriptions()
+        {
+            var subscriptions = new Subscription[]
+            {
+                ObjectMother.ExistingSubscription("Node1"),
+                ObjectMother.ExistingSubscription("Node2"),
+                ObjectMother.ExistingSubscription("Node2")
+            };
+
+            persistence.Persist(subscriptions);
+
+            persistence.DeleteSubscriptions(subscriptions.Take(2));
+
+            persistence.LoadSubscriptions("Node1", SubscriptionRole.Subscribes)
+                .ShouldHaveCount(0);
+            persistence.LoadSubscriptions("Node2", SubscriptionRole.Subscribes)
+                .ShouldHaveTheSameElementsAs(subscriptions.Skip(2));
+        }
     }
 }

--- a/src/FubuTransportation.RavenDb/RavenDbSubscriptionPersistence.cs
+++ b/src/FubuTransportation.RavenDb/RavenDbSubscriptionPersistence.cs
@@ -98,5 +98,13 @@ namespace FubuTransportation.RavenDb
                 }
             });
         }
+
+        public void DeleteSubscriptions(IEnumerable<Subscription> subscriptions)
+        {
+            _transaction.Execute<IDocumentSession>(session => {
+                var docs = session.Load<Subscription>(subscriptions.Select(x => x.Id).Cast<ValueType>());
+                docs.Each(x => session.Delete(x));
+            });
+        }
     }
 }

--- a/src/FubuTransportation.Storyteller/Fixtures/RunningNode.cs
+++ b/src/FubuTransportation.Storyteller/Fixtures/RunningNode.cs
@@ -74,9 +74,9 @@ namespace FubuTransportation.Storyteller.Fixtures
 
         }
 
-        public IEnumerable<Subscription> PersistedSubscriptions()
+        public IEnumerable<Subscription> PersistedSubscriptions(SubscriptionRole role = SubscriptionRole.Publishes)
         {
-            return _runtime.Factory.Get<ISubscriptionRepository>().LoadSubscriptions(SubscriptionRole.Publishes);
+            return _runtime.Factory.Get<ISubscriptionRepository>().LoadSubscriptions(role);
         }
 
 
@@ -94,6 +94,11 @@ namespace FubuTransportation.Storyteller.Fixtures
         {
             return _runtime.Factory.Get<ISubscriptionPersistence>()
                 .NodesForGroup(_runtime.Factory.Get<ChannelGraph>().Name);
+        }
+
+        public void RemoveSubscriptions()
+        {
+            _runtime.Factory.Get<IServiceBus>().RemoveSubscriptionsForThisNodeAsync().Wait();
         }
     }
 }

--- a/src/FubuTransportation.Storyteller/Fixtures/Subscriptions/SubscriptionsFixture.cs
+++ b/src/FubuTransportation.Storyteller/Fixtures/Subscriptions/SubscriptionsFixture.cs
@@ -72,11 +72,24 @@ namespace FubuTransportation.Storyteller.Fixtures.Subscriptions
                 .MatchOn(x => x.NodeName, x => x.MessageType, x => x.Source, x => x.Receiver);
         }
 
+        public IGrammar TheLocalSubscriptionsAre()
+        {
+            return VerifySetOf(() => _node.PersistedSubscriptions(SubscriptionRole.Subscribes))
+                .Titled("The persisted roles for subscribing are")
+                .MatchOn(x => x.NodeName, x => x.MessageType, x => x.Source, x => x.Receiver);
+        }
+
         public IGrammar ThePersistedTransportNodesAre()
         {
             return VerifySetOf(() => _node.PersistedNodes().Select(x => new TransportNodeItem(x)))
                 .Titled("The persisted transport nodes are")
                 .MatchOn(x => x.NodeName, x => x.Address);
+        }
+
+        [FormatAs("Node {Key} removes local subscriptions")]
+        public void NodeRemovesLocalSubscritpions(string Key)
+        {
+            _nodes[Key].RemoveSubscriptions();
         }
     }
 

--- a/src/FubuTransportation.Storyteller/Tests/Subscriptions/Remove_local_subscriptions.xml
+++ b/src/FubuTransportation.Storyteller/Tests/Subscriptions/Remove_local_subscriptions.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<Test name="Remove local subscriptions" lifecycle="Regression" retryAttemptNumber="0">
+  <Subscriptions>
+    <LoadNode isStep="True" Key="Publisher" Registry="PublishingRegistry" ReplyUri="memory://publisher1" />
+    <LoadNode isStep="True" Key="Subscriber" Registry="HasLocalSubscriptionsRegistry" ReplyUri="memory://subscriber1" />
+    <LoadNode isStep="True" Key="SubscriberTwo" Registry="HasLocalSubscriptionsRegistry" ReplyUri="memory://subscriber2" />
+    <NodeRemovesLocalSubscritpions isStep="True" Key="Subscriber" />
+    <ForNode isStep="True" Key="Publisher" />
+    <TheActiveSubscriptionsAre isStep="True">
+      <rows>
+        <row isStep="True" NodeName="Publishing" MessageType="FubuTransportation.Storyteller.Support.OneMessage" Source="memory://harness/publisher1" Receiver="memory://subscriber2" />
+        <row isStep="True" NodeName="Publishing" MessageType="FubuTransportation.Storyteller.Support.TwoMessage" Source="memory://harness/publisher1" Receiver="memory://subscriber2" />
+      </rows>
+    </TheActiveSubscriptionsAre>
+    <ThePersistedSubscriptionsAre isStep="True">
+      <rows>
+        <row isStep="True" NodeName="Publishing" MessageType="FubuTransportation.Storyteller.Support.OneMessage" Source="memory://harness/publisher1" Receiver="memory://subscriber2" />
+        <row isStep="True" NodeName="Publishing" MessageType="FubuTransportation.Storyteller.Support.TwoMessage" Source="memory://harness/publisher1" Receiver="memory://subscriber2" />
+      </rows>
+    </ThePersistedSubscriptionsAre>
+    <ForNode isStep="True" Key="Subscriber" />
+    <Comment><![CDATA[The other "LocalSubscriber" node will still have its subscriptions.]]></Comment>
+    <TheLocalSubscriptionsAre isStep="True">
+      <rows>
+        <row isStep="True" NodeName="LocalSubscriber" MessageType="FubuTransportation.Storyteller.Support.OneMessage" Source="memory://harness/publisher1" Receiver="memory://subscriber2" />
+        <row isStep="True" NodeName="LocalSubscriber" MessageType="FubuTransportation.Storyteller.Support.TwoMessage" Source="memory://harness/publisher1" Receiver="memory://subscriber2" />
+      </rows>
+    </TheLocalSubscriptionsAre>
+  </Subscriptions>
+</Test>

--- a/src/FubuTransportation.Testing/FubuTransportation.Testing.csproj
+++ b/src/FubuTransportation.Testing/FubuTransportation.Testing.csproj
@@ -625,6 +625,7 @@
     <Compile Include="Scheduling\ThreadSchedulerTester.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="ServiceBus_RemoveSubscriptions_Tester.cs" />
     <Compile Include="Subscriptions\SubscriptionCache_clearing_tester.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/FubuTransportation.Testing/Monitoring/RiggedServiceBus.cs
+++ b/src/FubuTransportation.Testing/Monitoring/RiggedServiceBus.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Web.UI;
 using NUnit.Framework;
 
 namespace FubuTransportation.Testing.Monitoring
@@ -129,6 +128,11 @@ namespace FubuTransportation.Testing.Monitoring
         }
 
         public Task SendAndWait<T>(T message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveSubscriptionsForThisNode()
         {
             throw new NotImplementedException();
         }

--- a/src/FubuTransportation.Testing/Monitoring/RiggedServiceBus.cs
+++ b/src/FubuTransportation.Testing/Monitoring/RiggedServiceBus.cs
@@ -137,7 +137,7 @@ namespace FubuTransportation.Testing.Monitoring
             throw new NotImplementedException();
         }
 
-        public void RemoveSubscriptionsForThisNode()
+        public Task RemoveSubscriptionsForThisNodeAsync()
         {
             throw new NotImplementedException();
         }

--- a/src/FubuTransportation.Testing/Monitoring/RiggedServiceBus.cs
+++ b/src/FubuTransportation.Testing/Monitoring/RiggedServiceBus.cs
@@ -132,6 +132,11 @@ namespace FubuTransportation.Testing.Monitoring
             throw new NotImplementedException();
         }
 
+        public Task SendAndWait<T>(Uri destination, T message)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RemoveSubscriptionsForThisNode()
         {
             throw new NotImplementedException();

--- a/src/FubuTransportation.Testing/RecordingServiceBusTester.cs
+++ b/src/FubuTransportation.Testing/RecordingServiceBusTester.cs
@@ -86,5 +86,19 @@ namespace FubuTransportation.Testing
             sentTo.Destination.ShouldEqual(destination);
             sentTo.Message.ShouldBeTheSameAs(message);
         }
+
+        [Test]
+        public void send_to_destination_and_wait()
+        {
+            var destination = new Uri("memory://blah");
+            var message = new Message1();
+            var bus = new RecordingServiceBus();
+
+            bus.SendAndWait(destination, message);
+
+            var sentTo = bus.SentDirectlyTo.Single();
+            sentTo.Destination.ShouldEqual(destination);
+            sentTo.Message.ShouldBeTheSameAs(message);
+        }
     }
 }

--- a/src/FubuTransportation.Testing/ServiceBus_RemoveSubscriptions_Tester.cs
+++ b/src/FubuTransportation.Testing/ServiceBus_RemoveSubscriptions_Tester.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FubuCore;
+using FubuTestingSupport;
+using FubuTransportation.Runtime;
+using FubuTransportation.Subscriptions;
+using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace FubuTransportation.Testing
+{
+    [TestFixture]
+    public class ServiceBus_RemoveSubscriptions_Tester : InteractionContext<ServiceBus>
+    {
+        private IList<Envelope> TheEnvelopesSent
+        {
+            get
+            {
+                return MockFor<IEnvelopeSender>().GetArgumentsForCallsMadeOn(x => x.Send(null))
+                    .Select(x => x[0] as Envelope)
+                    .ToList();
+            }
+        }
+
+        [Test]
+        public void sends_subscriptions_removed()
+        {
+            var local = new Uri("memory://node1");
+            var subscriptions = new[]
+            {
+                new Subscription
+                {
+                    Receiver = local,
+                    Source = new Uri("memory://node2"),
+                },
+                new Subscription
+                {
+                    Receiver = local,
+                    Source = new Uri("memory://node3"),
+                }
+            };
+            MockFor<ISubscriptionRepository>().Expect(x => x.LoadSubscriptions(SubscriptionRole.Subscribes))
+                .Return(subscriptions);
+            MockFor<ISubscriptionRepository>().Expect(x => x.RemoveLocalSubscriptions())
+                .Return(subscriptions);
+
+            ClassUnderTest.RemoveSubscriptionsForThisNode();
+
+            var envelopes = TheEnvelopesSent;
+            envelopes.ShouldHaveCount(2);
+            envelopes.Any(x => x.Destination == new Uri("memory://node2")).ShouldBeTrue();
+            envelopes.Any(x => x.Destination == new Uri("memory://node3")).ShouldBeTrue();
+            envelopes.Each(x => x.Message.As<SubscriptionsRemoved>().Receiver.ShouldEqual(local));
+        }
+    }
+}

--- a/src/FubuTransportation.Testing/ServiceBus_RemoveSubscriptions_Tester.cs
+++ b/src/FubuTransportation.Testing/ServiceBus_RemoveSubscriptions_Tester.cs
@@ -45,7 +45,7 @@ namespace FubuTransportation.Testing
             MockFor<ISubscriptionRepository>().Expect(x => x.RemoveLocalSubscriptions())
                 .Return(subscriptions);
 
-            ClassUnderTest.RemoveSubscriptionsForThisNode();
+            ClassUnderTest.RemoveSubscriptionsForThisNodeAsync();
 
             var envelopes = TheEnvelopesSent;
             envelopes.ShouldHaveCount(2);

--- a/src/FubuTransportation.Testing/Subscriptions/SubscriptionRepositoryTester.cs
+++ b/src/FubuTransportation.Testing/Subscriptions/SubscriptionRepositoryTester.cs
@@ -267,5 +267,32 @@ namespace FubuTransportation.Testing.Subscriptions
             persistence.LoadSubscriptions(TheNodeName, SubscriptionRole.Subscribes)
                 .ShouldHaveCount(0);
         }
+
+        [Test]
+        public void remove_subscriptions_for_receiver()
+        {
+            var differentNode = ObjectMother.ExistingSubscription("DifferentNode");
+            var differentReceiver = ObjectMother.ExistingSubscription();
+            differentReceiver.Receiver = new Uri("memory://other_receiver");
+
+            var subscriptions = new[]
+            {
+                ObjectMother.ExistingSubscription(),
+                ObjectMother.ExistingSubscription(),
+                ObjectMother.ExistingSubscription(),
+                differentNode,
+                differentReceiver
+            };
+
+            subscriptions.Each(x => x.Role = SubscriptionRole.Publishes);
+            persistence.Persist(subscriptions);
+
+            theRepository.RemoveSubscriptionsForReceiver(subscriptions[0].Receiver);
+
+            persistence.LoadSubscriptions(TheNodeName, SubscriptionRole.Publishes)
+                .ShouldHaveTheSameElementsAs(differentReceiver);
+            persistence.LoadSubscriptions("DifferentNode", SubscriptionRole.Publishes)
+                .ShouldHaveTheSameElementsAs(differentNode);
+        }
     }
 }

--- a/src/FubuTransportation.Testing/Subscriptions/SubscriptionRepositoryTester.cs
+++ b/src/FubuTransportation.Testing/Subscriptions/SubscriptionRepositoryTester.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FubuTestingSupport;
 using FubuTransportation.Configuration;
@@ -244,7 +245,27 @@ namespace FubuTransportation.Testing.Subscriptions
             theRepository.RemoveOwnershipFromNode(fooNode.Id, subject);
 
             fooNode.OwnedTasks.ShouldNotContain(subject);
+        }
 
+        [Test]
+        public void remove_local_subscriptions()
+        {
+            var subscriptions = new[] { ObjectMother.NewSubscription(), ObjectMother.NewSubscription() };
+            subscriptions.Each(x =>
+            {
+                x.Receiver = channelGraph.ReplyChannelFor("foo");
+                x.Source = new Uri("foo://source");
+            });
+
+            theRepository.PersistSubscriptions(subscriptions);
+            persistence.LoadSubscriptions(TheNodeName, SubscriptionRole.Subscribes)
+                .ShouldHaveTheSameElementsAs(subscriptions);
+
+            var removed = theRepository.RemoveLocalSubscriptions();
+            removed.ShouldHaveTheSameElementsAs(subscriptions);
+
+            persistence.LoadSubscriptions(TheNodeName, SubscriptionRole.Subscribes)
+                .ShouldHaveCount(0);
         }
     }
 }

--- a/src/FubuTransportation.Testing/Subscriptions/SubscriptionsHandlerTester.cs
+++ b/src/FubuTransportation.Testing/Subscriptions/SubscriptionsHandlerTester.cs
@@ -131,4 +131,43 @@ namespace FubuTransportation.Testing.Subscriptions
             });
         }
     }
+
+    [TestFixture]
+    public class when_handling_subscriptions_removed : InteractionContext<SubscriptionsHandler>
+    {
+        private SubscriptionsRemoved theMessage;
+
+        protected override void beforeEach()
+        {
+            Services.PartialMockTheClassUnderTest();
+
+            ClassUnderTest.Expect(x => x.ReloadSubscriptions());
+            ClassUnderTest.Expect(x => x.UpdatePeers());
+
+            theMessage = new SubscriptionsRemoved
+            {
+                Receiver = new Uri("memory://receiver")
+            };
+            ClassUnderTest.Handle(theMessage);
+        }
+
+        [Test]
+        public void should_remove_subscriptions_from_repository()
+        {
+            MockFor<ISubscriptionRepository>()
+                .AssertWasCalled(x => x.RemoveSubscriptionsForReceiver(theMessage.Receiver));
+        }
+
+        [Test]
+        public void should_reload_subscriptions()
+        {
+            ClassUnderTest.AssertWasCalled(x => x.ReloadSubscriptions());
+        }
+
+        [Test]
+        public void should_update_peers()
+        {
+            ClassUnderTest.AssertWasCalled(x => x.UpdatePeers());
+        }
+    }
 }

--- a/src/FubuTransportation/FubuTransportation.csproj
+++ b/src/FubuTransportation/FubuTransportation.csproj
@@ -357,6 +357,7 @@
     <Compile Include="Subscriptions\SubscriptionRole.cs" />
     <Compile Include="Subscriptions\SubscriptionsChanged.cs" />
     <Compile Include="Subscriptions\SubscriptionsHandler.cs" />
+    <Compile Include="Subscriptions\SubscriptionsRemoved.cs" />
     <Compile Include="Subscriptions\TransportNode.cs" />
     <Compile Include="TaskExtensions.cs" />
     <Compile Include="TestSupport\ClearAllTransports.cs" />

--- a/src/FubuTransportation/IServiceBus.cs
+++ b/src/FubuTransportation/IServiceBus.cs
@@ -52,6 +52,16 @@ namespace FubuTransportation
         Task SendAndWait<T>(T message);
 
         /// <summary>
+        /// Send a message to a specific destination and await an acknowledgment
+        /// that the message has been processed.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="destination">The destination to send to</param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        Task SendAndWait<T>(Uri destination, T message);
+
+        /// <summary>
         /// Unsubscribes from any messages this node was locally subscribed to.
         /// </summary>
         void RemoveSubscriptionsForThisNode();

--- a/src/FubuTransportation/IServiceBus.cs
+++ b/src/FubuTransportation/IServiceBus.cs
@@ -64,6 +64,6 @@ namespace FubuTransportation
         /// <summary>
         /// Unsubscribes from any messages this node was locally subscribed to.
         /// </summary>
-        void RemoveSubscriptionsForThisNode();
+        Task RemoveSubscriptionsForThisNodeAsync();
     }
 }

--- a/src/FubuTransportation/IServiceBus.cs
+++ b/src/FubuTransportation/IServiceBus.cs
@@ -50,5 +50,10 @@ namespace FubuTransportation
         /// <param name="message"></param>
         /// <returns></returns>
         Task SendAndWait<T>(T message);
+
+        /// <summary>
+        /// Unsubscribes from any messages this node was locally subscribed to.
+        /// </summary>
+        void RemoveSubscriptionsForThisNode();
     }
 }

--- a/src/FubuTransportation/ImportHandlers.cs
+++ b/src/FubuTransportation/ImportHandlers.cs
@@ -22,7 +22,7 @@ namespace FubuTransportation
             // across HandlerSource problem.
             handlers.Add(HandlerCall.For<SubscriptionsHandler>(x => x.Handle(new SubscriptionRequested())));
             handlers.Add(HandlerCall.For<SubscriptionsHandler>(x => x.Handle(new SubscriptionsChanged())));
-
+            handlers.Add(HandlerCall.For<SubscriptionsHandler>(x => x.Handle(new SubscriptionsRemoved())));
 
 
             handlers.Add(HandlerCall.For<MonitoringControlHandler>(x => x.Handle(new TakeOwnershipRequest())));

--- a/src/FubuTransportation/RecordingServiceBus.cs
+++ b/src/FubuTransportation/RecordingServiceBus.cs
@@ -60,6 +60,13 @@ namespace FubuTransportation
             return Task.Factory.StartNew(() => Await.Add(message));
         }
 
+
+        public Task SendAndWait<T>(Uri destination, T message)
+        {
+            SentDirectlyTo.Add(new SentDirectlyToMessage { Destination = destination, Message = message });
+            return Task.Factory.StartNew(() => Await.Add(message));
+        }
+
         public void RemoveSubscriptionsForThisNode()
         {
         }

--- a/src/FubuTransportation/RecordingServiceBus.cs
+++ b/src/FubuTransportation/RecordingServiceBus.cs
@@ -67,8 +67,9 @@ namespace FubuTransportation
             return Task.Factory.StartNew(() => Await.Add(message));
         }
 
-        public void RemoveSubscriptionsForThisNode()
+        public Task RemoveSubscriptionsForThisNodeAsync()
         {
+            return Task.FromResult(false);
         }
 
         public class DelayedMessage

--- a/src/FubuTransportation/RecordingServiceBus.cs
+++ b/src/FubuTransportation/RecordingServiceBus.cs
@@ -60,6 +60,10 @@ namespace FubuTransportation
             return Task.Factory.StartNew(() => Await.Add(message));
         }
 
+        public void RemoveSubscriptionsForThisNode()
+        {
+        }
+
         public class DelayedMessage
         {
             public TimeSpan Delay;

--- a/src/FubuTransportation/ServiceBus.cs
+++ b/src/FubuTransportation/ServiceBus.cs
@@ -83,10 +83,21 @@ namespace FubuTransportation
 
         public Task SendAndWait<T>(T message)
         {
+            return GetSendAndWaitTask(message);
+        }
+
+        public Task SendAndWait<T>(Uri destination, T message)
+        {
+            return GetSendAndWaitTask(message, destination);
+        }
+
+        private Task GetSendAndWaitTask<T>(T message, Uri destination = null)
+        {
             var envelope = new Envelope
             {
                 Message = message,
-                AckRequested = true
+                AckRequested = true,
+                Destination = destination
             };
 
             var listener = new ReplyListener<Acknowledgement>(_events, envelope.CorrelationId, 10.Minutes());

--- a/src/FubuTransportation/Subscriptions/ISubscriptionPersistence.cs
+++ b/src/FubuTransportation/Subscriptions/ISubscriptionPersistence.cs
@@ -17,5 +17,6 @@ namespace FubuTransportation.Subscriptions
         TransportNode LoadNode(string nodeId);
 
         void Alter(string id, Action<TransportNode> alteration);
+        void DeleteSubscriptions(IEnumerable<Subscription> subscriptions);
     }
 }

--- a/src/FubuTransportation/Subscriptions/ISubscriptionRepository.cs
+++ b/src/FubuTransportation/Subscriptions/ISubscriptionRepository.cs
@@ -22,5 +22,6 @@ namespace FubuTransportation.Subscriptions
         void RemoveOwnershipFromNode(string nodeId, Uri subject);
         void RemoveOwnershipFromNode(string nodeId, IEnumerable<Uri> subjects);
         void RemoveOwnershipFromThisNode(IEnumerable<Uri> subjects);
+        IEnumerable<Subscription> RemoveLocalSubscriptions();
     }
 }

--- a/src/FubuTransportation/Subscriptions/ISubscriptionRepository.cs
+++ b/src/FubuTransportation/Subscriptions/ISubscriptionRepository.cs
@@ -23,5 +23,6 @@ namespace FubuTransportation.Subscriptions
         void RemoveOwnershipFromNode(string nodeId, IEnumerable<Uri> subjects);
         void RemoveOwnershipFromThisNode(IEnumerable<Uri> subjects);
         IEnumerable<Subscription> RemoveLocalSubscriptions();
+        void RemoveSubscriptionsForReceiver(Uri receiver);
     }
 }

--- a/src/FubuTransportation/Subscriptions/InMemorySubscriptionPersistence.cs
+++ b/src/FubuTransportation/Subscriptions/InMemorySubscriptionPersistence.cs
@@ -88,8 +88,11 @@ namespace FubuTransportation.Subscriptions
                 var node = _nodes.FirstOrDefault(x => x.Id == id);
                 alteration(node);
             });
+        }
 
-
+        public void DeleteSubscriptions(IEnumerable<Subscription> subscriptions)
+        {
+            _lock.Write(() => subscriptions.Each(x => _subscriptions.Remove(x.Id)));
         }
     }
 }

--- a/src/FubuTransportation/Subscriptions/SubscriptionRepository.cs
+++ b/src/FubuTransportation/Subscriptions/SubscriptionRepository.cs
@@ -88,6 +88,20 @@ namespace FubuTransportation.Subscriptions
             _persistence.Alter(_graph.NodeId, node => subjects.Each(node.RemoveOwnership));
         }
 
+        public IEnumerable<Subscription> RemoveLocalSubscriptions()
+        {
+            var subscriptions = LoadSubscriptions(SubscriptionRole.Subscribes).ToList();
+            if (!subscriptions.Any())
+                return Enumerable.Empty<Subscription>();
+
+            var protocol = subscriptions.First().Source.Scheme;
+            var uri = _graph.ReplyChannelFor(protocol);
+            var localSubscriptions = subscriptions.Where(x => x.Receiver == uri).ToList();
+
+            _persistence.DeleteSubscriptions(localSubscriptions);
+            return localSubscriptions;
+        }
+
         public IEnumerable<Subscription> LoadSubscriptions(SubscriptionRole role)
         {
             return _persistence.LoadSubscriptions(_graph.Name, role);

--- a/src/FubuTransportation/Subscriptions/SubscriptionRepository.cs
+++ b/src/FubuTransportation/Subscriptions/SubscriptionRepository.cs
@@ -102,6 +102,17 @@ namespace FubuTransportation.Subscriptions
             return localSubscriptions;
         }
 
+        public void RemoveSubscriptionsForReceiver(Uri receiver)
+        {
+            var subscriptions = LoadSubscriptions(SubscriptionRole.Publishes)
+                .Where(x => x.Receiver == receiver)
+                .ToList();
+            if (!subscriptions.Any())
+                return;
+
+            _persistence.DeleteSubscriptions(subscriptions);
+        }
+
         public IEnumerable<Subscription> LoadSubscriptions(SubscriptionRole role)
         {
             return _persistence.LoadSubscriptions(_graph.Name, role);

--- a/src/FubuTransportation/Subscriptions/SubscriptionsHandler.cs
+++ b/src/FubuTransportation/Subscriptions/SubscriptionsHandler.cs
@@ -35,6 +35,11 @@ namespace FubuTransportation.Subscriptions
             // Reload here!
             Handle(new SubscriptionsChanged());
 
+            UpdatePeers();
+        }
+
+        public virtual void UpdatePeers()
+        {
             var peers = _repository.FindPeers();
             peers.Each(SendSubscriptionChangedToPeer);
         }
@@ -48,6 +53,13 @@ namespace FubuTransportation.Subscriptions
             };
 
             _sender.Send(envelope);
+        }
+
+        public void Handle(SubscriptionsRemoved message)
+        {
+            _repository.RemoveSubscriptionsForReceiver(message.Receiver);
+            ReloadSubscriptions();
+            UpdatePeers();
         }
     }
 }

--- a/src/FubuTransportation/Subscriptions/SubscriptionsRemoved.cs
+++ b/src/FubuTransportation/Subscriptions/SubscriptionsRemoved.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace FubuTransportation.Subscriptions
+{
+    public class SubscriptionsRemoved
+    {
+        public Uri Receiver { get; set; }
+    }
+}


### PR DESCRIPTION
I need this for some automated tests against a service that need to clean up after themselves. This only supports removing subscriptions from SubscribeLocally() calls, not SubscribeAt().

This is pretty much complete, but I want to make sure it works well for my case before it's pulled in.